### PR TITLE
Rework config.w32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,9 +64,7 @@ build_script:
 
     copy C:\projects\mpdecimal\mpdecimal-2.4.2\vcbuild\dist%INT_SIZE%\mpdecimal.h C:\projects\php-src\deps\include\mpdecimal.h
 
-    copy C:\projects\mpdecimal\mpdecimal-2.4.2\vcbuild\dist%INT_SIZE%\libmpdec-2.4.2.lib C:\projects\php-src\deps\lib\libmpdec.lib
-
-    copy C:\projects\mpdecimal\mpdecimal-2.4.2\vcbuild\dist%INT_SIZE%\libmpdec-2.4.2.dll C:\projects\php-decimal\bin\libmpdec.dll
+    copy C:\projects\mpdecimal\mpdecimal-2.4.2\vcbuild\dist%INT_SIZE%\libmpdec-2.4.2.lib C:\projects\php-src\deps\lib\libmpdec_a.lib
 
     cd C:\projects\php-src
 

--- a/config.w32
+++ b/config.w32
@@ -19,8 +19,8 @@ if (PHP_DECIMAL == "yes") {
     if (CHECK_HEADER_ADD_INCLUDE(DECIMAL_EXT_DEP_HEADER, "CFLAGS_DECIMAL")) {
         if (PHP_DECIMAL_SHARED && CHECK_LIB(DECIMAL_EXT_DEP_LIB_SHARED, DECIMAL_EXT_NAME, PHP_DECIMAL)) {
             setup_ok = true;
+            libmpdec_shared = true;
         } else if (CHECK_LIB(DECIMAL_EXT_DEP_LIB_STATIC, DECIMAL_EXT_NAME, PHP_DECIMAL)) {
-            libmpdec_shared = false;
             setup_ok = true;
         }
     }

--- a/config.w32
+++ b/config.w32
@@ -5,8 +5,8 @@ var DECIMAL_EXT_NAME        ="decimal";
 var DECIMAL_EXT_API         ="php_decimal.c";
 var DECIMAL_EXT_DEP_HEADER  ="mpdecimal.h";
 var DECIMAL_EXT_FLAGS       ="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1";
-var DECIMAL_EXT_DEP_LIB_SHARED ="libmpdec_a.lib";
-var DECIMAL_EXT_DEP_LIB_STATIC ="libmpdec.lib";
+var DECIMAL_EXT_DEP_LIB_SHARED ="libmpdec.lib";
+var DECIMAL_EXT_DEP_LIB_STATIC ="libmpdec_a.lib";
 
 /* --------------------------------------------------------------------- */
 

--- a/config.w32
+++ b/config.w32
@@ -5,15 +5,31 @@ var DECIMAL_EXT_NAME        ="decimal";
 var DECIMAL_EXT_API         ="php_decimal.c";
 var DECIMAL_EXT_DEP_HEADER  ="mpdecimal.h";
 var DECIMAL_EXT_FLAGS       ="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1";
-var DECIMAL_EXT_DEP_LIB     ="libmpdec.lib";
+var DECIMAL_EXT_DEP_LIB_SHARED ="libmpdec_a.lib";
+var DECIMAL_EXT_DEP_LIB_STATIC ="libmpdec.lib";
 
 /* --------------------------------------------------------------------- */
 
 ARG_WITH("decimal", "for decimal support", "yes");
 
 if (PHP_DECIMAL == "yes") {
-    if (CHECK_LIB(DECIMAL_EXT_DEP_LIB, DECIMAL_EXT_NAME, PHP_DECIMAL) && CHECK_HEADER_ADD_INCLUDE(DECIMAL_EXT_DEP_HEADER, "CFLAGS_DECIMAL")) {
+    var setup_ok = false;
+    var libmpdec_shared = false;
+
+    if (CHECK_HEADER_ADD_INCLUDE(DECIMAL_EXT_DEP_HEADER, "CFLAGS_DECIMAL")) {
+        if (PHP_DECIMAL_SHARED && CHECK_LIB(DECIMAL_EXT_DEP_LIB_SHARED, DECIMAL_EXT_NAME, PHP_DECIMAL)) {
+            setup_ok = true;
+        } else if (CHECK_LIB(DECIMAL_EXT_DEP_LIB_STATIC, DECIMAL_EXT_NAME, PHP_DECIMAL)) {
+            libmpdec_shared = false;
+            setup_ok = true;
+        }
+    }
+
+    if (setup_ok) {
         EXTENSION(DECIMAL_EXT_NAME, DECIMAL_EXT_API, PHP_DECIMAL_SHARED, DECIMAL_EXT_FLAGS);
+        if (libmpdec_shared) {
+            ADD_FLAG("CFLAGS_DECIMAL", "/D USE_DLL=1");
+        }
     } else {
         WARNING("decimal not enabled; libraries and headers not found");
     }


### PR DESCRIPTION
The rework adapts the lib names expectation to the usual naming scheme in PHP. The dependency libs header need a light patching, the current packages are accessible here https://windows.php.net/downloads/pecl/deps/. The latest PECL release build was redone using this config.w32 patch and the linked deps.

Thanks.