### PR TITLE
PHP 8 Support for decimal 2.x

### DIFF
--- a/src/arginfo.h
+++ b/src/arginfo.h
@@ -42,7 +42,7 @@
 #if PHP_VERSION_ID >= 70200
 #define PHP_DECIMAL_ARGINFO_RETURN_NUMBER(cls, name, required_num_args) \
     static const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
-        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE_CLASS_CONST(PHP_DECIMAL_NUMBER_FQCN, 0), 0, 0},
+        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_INIT_CLASS_CONST(PHP_DECIMAL_NUMBER_FQCN, 0, 0), 0},
 #else
 #define PHP_DECIMAL_ARGINFO_RETURN_NUMBER(cls, name, required_num_args) \
     static const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
@@ -52,7 +52,7 @@
 #if PHP_VERSION_ID >= 70200
 #define PHP_DECIMAL_ARGINFO_RETURN_DECIMAL(cls, name, required_num_args) \
     const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
-        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE_CLASS_CONST(PHP_DECIMAL_DECIMAL_FQCN, 0), 0, 0},
+        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_INIT_CLASS_CONST(PHP_DECIMAL_DECIMAL_FQCN, 0, 0), 0},
 #else
 #define PHP_DECIMAL_ARGINFO_RETURN_DECIMAL(cls, name, required_num_args) \
     const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
@@ -62,7 +62,7 @@
 #if PHP_VERSION_ID >= 70200
 #define PHP_DECIMAL_ARGINFO_RETURN_RATIONAL(cls, name, required_num_args) \
     const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
-        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE_CLASS_CONST(PHP_DECIMAL_RATIONAL_FQCN, 0), 0, 0},
+        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_INIT_CLASS_CONST(PHP_DECIMAL_RATIONAL_FQCN, 0, 0), 0},
 #else
 #define PHP_DECIMAL_ARGINFO_RETURN_RATIONAL(cls, name, required_num_args) \
     const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
@@ -73,7 +73,7 @@
 #if PHP_VERSION_ID >= 70200
 #define PHP_DECIMAL_ARGINFO_RETURN_NUMBER(cls, name, required_num_args) \
     static const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \
-        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_ENCODE_CLASS_CONST(PHP_DECIMAL_RATIONAL_FQCN, 0), 0, 0},
+        {(const char*)(zend_uintptr_t)(required_num_args), ZEND_TYPE_INIT_CLASS_CONST(PHP_DECIMAL_RATIONAL_FQCN, 0, 0), 0},
 #else
 #define PHP_DECIMAL_ARGINFO_RETURN_NUMBER(cls, name, required_num_args) \
     static const zend_internal_arg_info PHP_DECIMAL_ARGINFO_NAME(cls, name)[] = { \

--- a/src/decimal.c
+++ b/src/decimal.c
@@ -510,7 +510,7 @@ PHP_DECIMAL_METHOD(Decimal, valueOf)
     PHP_DECIMAL_PARSE_PARAMS(1, 2)
         Z_PARAM_ZVAL(val)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(prec)
+        Z_PARAM_LONG(prec)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     if (ZEND_NUM_ARGS() == 1) {
@@ -663,8 +663,8 @@ PHP_DECIMAL_METHOD(Decimal, round)
 
     PHP_DECIMAL_PARSE_PARAMS(0, 2)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(places)
-        Z_PARAM_STRICT_LONG(mode)
+        Z_PARAM_LONG(places)
+        Z_PARAM_LONG(mode)
     PHP_DECIMAL_PARSE_PARAMS_END()
     {
         php_decimal_t *obj = THIS_DECIMAL();
@@ -912,9 +912,9 @@ PHP_DECIMAL_METHOD(Decimal, toFixed)
 
     PHP_DECIMAL_PARSE_PARAMS(0, 3)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(places)
+        Z_PARAM_LONG(places)
         Z_PARAM_BOOL(commas)
-        Z_PARAM_STRICT_LONG(mode)
+        Z_PARAM_LONG(mode)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     RETURN_STR(php_decimal_mpd_to_fixed(THIS_DECIMAL_MPD(), places, commas, mode));
@@ -978,7 +978,7 @@ PHP_DECIMAL_METHOD(Decimal, toDecimal)
     zend_long prec;
 
     PHP_DECIMAL_PARSE_PARAMS(1, 1)
-        Z_PARAM_STRICT_LONG(prec)
+        Z_PARAM_LONG(prec)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     if (php_decimal_validate_prec(prec)) {

--- a/src/number.c
+++ b/src/number.c
@@ -503,7 +503,7 @@ PHP_DECIMAL_METHOD(Number, toDecimal)
     zend_long prec;
 
     PHP_DECIMAL_PARSE_PARAMS(1, 1)
-        Z_PARAM_STRICT_LONG(prec)
+        Z_PARAM_LONG(prec)
     PHP_DECIMAL_PARSE_PARAMS_END()
     {
         if (EXPECTED(php_decimal_validate_prec(prec))) {

--- a/src/rational.c
+++ b/src/rational.c
@@ -674,8 +674,8 @@ PHP_DECIMAL_METHOD(Rational, round)
 
     PHP_DECIMAL_PARSE_PARAMS(0, 2)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(places)
-        Z_PARAM_STRICT_LONG(mode)
+        Z_PARAM_LONG(places)
+        Z_PARAM_LONG(mode)
     PHP_DECIMAL_PARSE_PARAMS_END()
     {
         php_rational_t *res = php_rational();
@@ -846,9 +846,9 @@ PHP_DECIMAL_METHOD(Rational, toFixed)
 
     PHP_DECIMAL_PARSE_PARAMS(0, 3)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(places)
+        Z_PARAM_LONG(places)
         Z_PARAM_BOOL(commas)
-        Z_PARAM_STRICT_LONG(mode)
+        Z_PARAM_LONG(mode)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     RETURN_STR(php_decimal_rational_to_fixed(THIS_RATIONAL(), places, commas, mode));
@@ -866,7 +866,7 @@ PHP_DECIMAL_METHOD(Rational, toSci)
 
     PHP_DECIMAL_PARSE_PARAMS(0, 1)
         Z_PARAM_OPTIONAL
-        Z_PARAM_STRICT_LONG(prec)
+        Z_PARAM_LONG(prec)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     RETURN_STR(php_decimal_rational_to_sci(THIS_RATIONAL(), prec));
@@ -918,7 +918,7 @@ PHP_DECIMAL_METHOD(Rational, toDecimal)
     zend_long prec;
 
     PHP_DECIMAL_PARSE_PARAMS(1, 1)
-        Z_PARAM_STRICT_LONG(prec)
+        Z_PARAM_LONG(prec)
     PHP_DECIMAL_PARSE_PARAMS_END()
 
     if (php_decimal_validate_prec(prec)) {


### PR DESCRIPTION
WIP on 

- `ZEND_TYPE_ENCODE_CLASS_CONST` to `ZEND_TYPE_INIT_CLASS_CONST` looks it needs one more condition to 80000 https://github.com/php/php-src/commit/ac4e0f0852ce780e143013ceff45067a172e8a83 
- `Z_PARAM_STRICT_LONG` to `Z_PARAM_LONG` - implementation in 8.x are the same, but needs checking https://github.com/php/php-src/commit/8a0965e3d694037837a8f70f280e7d14dd7778eb


Ref https://github.com/php-decimal/ext-decimal/issues/43#issuecomment-740355156

