### PR TITLE
Added support for PIE

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,12 @@
+{
+    "name": "php-decimal/ext-decimal",
+    "type": "php-ext",
+    "license": "MIT",
+    "description": "Correctly-rounded, arbitrary precision decimal floating-point arithmetic in PHP",
+    "require": {
+        "php": ">= 7.2.0"
+    },
+    "php-ext": {
+        "extension-name": "decimal"
+    }
+}


### PR DESCRIPTION
Adds support for [PIE](https://github.com/php/pie).

Once merged, a maintainer would need to add this repo's URL to https://packagist.org/packages/submit :)

More info/documentation can be read on: https://github.com/php/pie/blob/main/docs/extension-maintainers.md
