### PR TITLE
Add dependency "json" for decimal extension in config

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -14,6 +14,7 @@ var DECIMAL_EXT_DEP_LIB_STATIC ="libmpdec_a.lib";
 ARG_WITH("decimal", "for decimal support", "no");
 
 if (PHP_DECIMAL == "yes") {
+    ADD_EXTENSION_DEP("decimal", "json");
     var setup_ok = false;
     var libmpdec_shared = false;
 


### PR DESCRIPTION
This only occurs when statically building decimal on Windows, otherwise it will make php.exe crashed. In short, decimal depends on json extension, but we need to ensure and explicitly loading json before decimal.

Related PR for StaticPHP project: https://github.com/crazywhalecc/static-php-cli/pull/1095