### PR TITLE
Fix segfault in do_operation handler (ext-decimal 2.0.x)

### DIFF
--- a/src/decimal.c
+++ b/src/decimal.c
@@ -397,6 +397,7 @@ static php_decimal_success_t php_decimal_do_operation_handler(zend_uchar opcode,
     /* Unsupported op type - return success to avoid casting. */
     if (UNEXPECTED(op == NULL)) {
         php_decimal_operator_not_supported();
+        ZVAL_UNDEF(result);
         return SUCCESS;
     }
 

--- a/src/number.c
+++ b/src/number.c
@@ -105,6 +105,7 @@ static php_decimal_success_t php_decimal_number_do_operation(zend_uchar opcode, 
     /* Unsupported operator - return success to avoid casting. */
     if (UNEXPECTED(func == NULL)) {
         php_decimal_operator_not_supported();
+        ZVAL_UNDEF(result);
         return SUCCESS;
     }
 

--- a/src/rational.c
+++ b/src/rational.c
@@ -316,6 +316,7 @@ static php_decimal_success_t php_decimal_rational_do_operation(zend_uchar opcode
     /* Unsupported operator - return success to avoid casting. */
     if (UNEXPECTED(op == NULL)) {
         php_decimal_operator_not_supported();
+        ZVAL_UNDEF(result);
         return SUCCESS;
     }
 


### PR DESCRIPTION
## Summary

- The `do_operation` handler segfaults when encountering unsupported opcodes (`ZEND_CONCAT`, `ZEND_BW_OR`, etc.)
- The handler throws `ArithmeticError` and returns `SUCCESS` without initializing the `result` zval, causing the VM's exception handler to crash in `zval_delref_p`
- Fix by adding `ZVAL_UNDEF(result)` before returning `SUCCESS` for unsupported operators

## Root Cause

This bug was introduced in commit `b8b4420` (Jan 2019, _"Alpha implementation of Number and Rational"_) when the unsupported-operator handling was changed from the 1.x behavior:

- **1.x**: `return FAILURE;` — engine falls through to type juggling (casting object to string/int)
- **2.0.x**: throws `ArithmeticError` + `return SUCCESS` + **`result` left uninitialized** — engine skips type juggling but crashes cleaning up the garbage `result` zval

This affects **all PHP versions** (8.2+), not only PHP 8.5. The `concat_function` → `do_operation(ZEND_CONCAT)` call path has existed since PHP 5.6 (commit `089f4967997`, Oct 2014). The `ZEND_TRY_BINARY_OBJECT_OPERATION` macro is identical between PHP 8.4 and 8.5.

## Test Plan

- [x] All 131 tests pass on PHP 8.2, 8.3, 8.4, 8.5 (previously 3 tests failed with SIGSEGV)
- [x] `Decimal/operators.phpt`, `Number/operators.phpt`, `Rational/operators.phpt` now pass
- [x] Verified no regression on supported operators (`+`, `-`, `*`, `/`, `%`, `**`, `<<`, `>>`)